### PR TITLE
Update print_colors.py

### DIFF
--- a/Colors/print_colors.py
+++ b/Colors/print_colors.py
@@ -1,7 +1,7 @@
 import sys
 
 
-class colors:
+class Colors:
     CYAN = "\033[36m"
     GREEN = "\033[32m"
     YELLOW = "\033[33m"
@@ -11,12 +11,12 @@ class colors:
 
 
 def printc(color, message):
-    print(color + message + colors.ENDC)
+    print(color + message + Colors.ENDC)
 
 
 # color which we print or import
-printc(colors.CYAN, sys.argv[1])
-printc(colors.GREEN, sys.argv[1])
-printc(colors.YELLOW, sys.argv[1])
-printc(colors.BLUE, sys.argv[1])
-printc(colors.RED, sys.argv[1])
+printc(Colors.CYAN, sys.argv[1])
+printc(Colors.GREEN, sys.argv[1])
+printc(Colors.YELLOW, sys.argv[1])
+printc(Colors.BLUE, sys.argv[1])
+printc(Colors.RED, sys.argv[1])


### PR DESCRIPTION
You should always use a capital for the first letter of a class name in Python